### PR TITLE
fix null pointer for situation when call registered function from console

### DIFF
--- a/src/pgr/dconsole/DCCommands.hx
+++ b/src/pgr/dconsole/DCCommands.hx
@@ -82,7 +82,7 @@ class DCCommands
 			var program = hScriptParser.parseString(input);
 			
 			// using exprReturn instead of execute to skip interp internal state reset.
-			var result = hScriptInterp.exprReturn(program); 
+			var result = hScriptInterp.execute(program); 
 			if (Std.is(result, Float) || Std.is(result, Bool) || result != null) { 
 				DC.logConfirmation(result);
 			}


### PR DESCRIPTION
When we call <code>exprReturn(program)</code>, then we got null pointer exception, cuz <code>locals</code> not initialized yet
