### PR TITLE
Support nested fields for the monitoring.

### DIFF
--- a/src/pgr/dconsole/DCMonitor.hx
+++ b/src/pgr/dconsole/DCMonitor.hx
@@ -77,6 +77,7 @@ class DCMonitor {
 					
 					if ( child != null)	
 						parent = child;
+					else break;
 				}
 				
 				output.push(v.alias + ':' + child + '\n');


### PR DESCRIPTION
In some cases are need to use that construction

``` Haxe
DC.monitorField(object, 'field.nestedField', 'someProp');
```

because 'field' for some reasons can be null:

``` Haxe
object.field = null;
// ...
DC.monitorField(object.field, 'nestedField', 'someProp');    // log error
```
